### PR TITLE
patch: show total eth staked on `/data-hub`

### DIFF
--- a/app/data-hub/page.tsx
+++ b/app/data-hub/page.tsx
@@ -78,7 +78,7 @@ export default async function Page() {
       ...totalValueSecuredData.sourceInfo,
     },
     {
-      label: "Validator Valuation",
+      label: "ETH Staked",
       value: formatLargeCurrency(
         beaconChainData.data.totalStakedEther * ethPrice.data.usd
       ),


### PR DESCRIPTION
Improve accuracy of security metric using total ETH staked value instead of simply validator count as validator accounts consolidate post-Pectra (`/data-hub`)