### PR TITLE
chore: update contact form fallback email to epic@ethereum.org

### DIFF
--- a/components/ContactForm/index.tsx
+++ b/components/ContactForm/index.tsx
@@ -15,7 +15,11 @@ import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
 import { sanitizeInput } from "@/lib/utils/sanitize"
 
-import { CONSUMER_DOMAINS, ENTERPRISE_EMAIL } from "@/lib/constants"
+import {
+  CONSUMER_DOMAINS,
+  ENTERPRISE_EMAIL,
+  WEBSITE_EMAIL,
+} from "@/lib/constants"
 
 import Link from "../ui/link"
 
@@ -197,7 +201,7 @@ const EnterpriseContactForm = () => {
           <>
             {t("errors.generalError")}{" "}
             <Link
-              href={`mailto:${ENTERPRISE_EMAIL}?subject=Enterprise%20inquiry`}
+              href={`mailto:${ENTERPRISE_EMAIL}?cc=${WEBSITE_EMAIL}&subject=Enterprise%20inquiry`}
               inline
               showDecorator
               className="text-nowrap text-current hover:text-current/80"

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,7 +9,8 @@ export const SITE_ORIGIN =
 
 export const MAINNET_GENESIS = "2015-07-30T15:26:13Z"
 
-export const ENTERPRISE_EMAIL = "enterprise@ethereum.org"
+export const ENTERPRISE_EMAIL = "epic@ethereum.org"
+export const WEBSITE_EMAIL = "website@ethereum.org"
 
 // Consumer email domains to block (enforced client-side for UX, server-side for security)
 export const CONSUMER_DOMAINS = [


### PR DESCRIPTION
## Summary

The footer "Get In Touch" form posts to `/api/contact`, which submits to the HubSpot Forms API. If that submission fails, the form shows an error with a `mailto:` fallback so the inquiry isn't lost. This updates that fallback address.

- `ENTERPRISE_EMAIL`: `enterprise@ethereum.org` → `epic@ethereum.org`
- Adds `WEBSITE_EMAIL` (`website@ethereum.org`), cc'd on the fallback `mailto:`

Resulting link: `mailto:epic@ethereum.org?cc=website@ethereum.org&subject=Enterprise%20inquiry`, displayed as `epic@ethereum.org` so the footer copy stays short.

## Scope note

This is the only email address in the repo. Successful submissions go to HubSpot (portal `147481544`), so **who gets notified on the happy path is configured in HubSpot, not here** — if those notifications should also move to epic@/website@, that change needs to be made in the HubSpot form settings.

## Test plan

- [x] `npx eslint lib/constants.ts components/ContactForm/index.tsx` — clean
- [x] `npx tsc --noEmit` — no errors in the touched files (pre-existing image-module errors in a fresh clone are unrelated, from `next-env.d.ts` not being generated yet)
- [ ] Manual: force a `/api/contact` failure and confirm the error link opens a draft to epic@ with website@ cc'd